### PR TITLE
Allow all FHIR REST verbs through CORS

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -102,6 +102,8 @@ services:
       # NB accessControlAllowOrigin is deprecated, but not noted in docs
       # https://github.com/traefik/traefik/issues/8796
       - "traefik.http.middlewares.fhirwall-${COMPOSE_PROJECT_NAME}-cors.headers.accessControlAllowOriginList=*"
+      # allow all verbs used by FHIR REST
+      - "traefik.http.middlewares.fhirwall-${COMPOSE_PROJECT_NAME}-cors.headers.accessControlAllowMethods=HEAD,GET,OPTIONS,PATCH,POST,PUT,DELETE"
       - "traefik.http.middlewares.fhirwall-${COMPOSE_PROJECT_NAME}-cors.headers.accessControlAllowHeaders=Authorization,Origin,Content-Type,Accept"
       - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.middlewares=fhirwall-${COMPOSE_PROJECT_NAME}-cors"
 


### PR DESCRIPTION
Allow all [FHIR REST](https://www.hl7.org/fhir/http.html) verbs through CORS