### PR TITLE
fix Primary Author column label

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
         {"expr":"$$.name[0].family","label":"Last Name"},
         {"expr":"$$.birthDate","label":"Birth Date"},
         {"dataType":"timeAgo","defaultSort":"asc","expr":"$$.extension[?(@.url=='http://isacc.app/time-of-last-unfollowedup-message')].valueDateTime","label":"Time Since Reply","sortBy":"time-of-last-unresponded-message"},
-        {"expr":"$$.generalPractitioner[0].display","label":"PrimaryAuthor","sortBy":"general-practitioner"}
+        {"expr":"$$.generalPractitioner[0].display","label":"Primary Author","sortBy":"general-practitioner"}
         ]
 
     depends_on:


### PR DESCRIPTION
Add space in the Primary Author label, was "PrimaryAuthor" - fixed to read "Primary Author"
![PrimaryAuthor](https://github.com/uwcirg/isacc-environments/assets/12942714/88af20e7-b5eb-4ee3-81d4-87088083263b)
