### PR TITLE
Use MESSAGING overrides for both ENROLLMENT and MESSAGING

### DIFF
--- a/dev/default.env
+++ b/dev/default.env
@@ -20,7 +20,6 @@ COMPOSE_PROJECT_NAME=
 # POSTGRES_IMAGE_TAG=override-tag-name
 # FEMR_IMAGE_TAG=override-tag-name
 # PROXY_IMAGE_TAG=override-tag-name
-# ENROLLMENT_IMAGE_TAG=override-tag-name
 # MESSAGING_IMAGE_TAG=override-tag-name
 # MESSAGINGSERVICE_IMAGE_TAG=override-tag-name
 # ISACCML_IMAGE_TAG=override-tag-name
@@ -31,7 +30,6 @@ COMPOSE_PROJECT_NAME=
 # uncomment & modify if using above development overrides
 # FEMR_CHECKOUT_DIR=
 # FHIRWALL_CHECKOUT_DIR=
-# ENROLLMENT_CHECKOUT_DIR=
 # MESSAGING_CHECKOUT_DIR=
 # MESSAGINGSERVICE_CHECKOUT_DIR=
 # ISACCML_CHECKOUT_DIR=

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -209,7 +209,7 @@ services:
 
 
   enrollment:
-    image: ghcr.io/uwcirg/isacc-messaging-client-sof:${ENROLLMENT_IMAGE_TAG:-latest}
+    image: ghcr.io/uwcirg/isacc-messaging-client-sof:${MESSAGING_IMAGE_TAG:-latest}
     environment:
       REACT_APP_DASHBOARD_URL: "https://femr.${BASE_DOMAIN:-localtest.me}"
       REACT_APP_CLIENT_ID: enrollment


### PR DESCRIPTION
Both ENROLLMENT and MESSAGING front end client apps use the same code base and config files.  Separate overrides confuse deploys and don't appear to be of use.  (I've experienced this at least 2x)

Use `MESSAGING_IMAGE_TAG` and `MESSAGING_CHECKOUT_DIR` for both ENROLLMENT and MESSAGING services.