### PR TITLE
patch bootstrap logging error due to service order

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -276,6 +276,7 @@ services:
       - internal
     depends_on:
       - redis
+      - logs
 
   isaccml:
     image: ghcr.io/uwcirg/isacc-ml:${ISACCML_IMAGE_TAG:-main}


### PR DESCRIPTION
Bootstrap order, messagingservice attempts to post to logserver before it's available.  Fixed by adding `logs` to messagingservice depends.

Example of `messagingservice` logs before this change:

```
messagingservice_1  | {"asctime": "2025-02-05 20:54:37,372", "name": "root", "levelname": "ERROR", "message": "404 Client Error: Not Found for url: https://logs.pb.isacc.dev.cirg.uw.edu/events", "exc_info": "Traceback (most recent call last):\n  File \"/opt/app/isacc_messaging/logserverhandler.py\", line 27, in emit\n    response.raise_for_status()\n  File \"/usr/local/lib/python3.11/site-packages/requests/models.py\", line 1024, in raise_for_status\n    raise HTTPError(http_error_msg, response=self)\nrequests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://logs.pb.isacc.dev.cirg.uw.edu/events"}
messagingservice_1  | {"asctime": "2025-02-05 20:54:37,311", "name": "isacc_messaging_event_logger", "levelname": "INFO", "message": "isacc messaging service logging initialized", "tags": ["testing", "logging", "events"], "version": "ISACC.24.12.02-8-gdc2740b"}
```