### PR TITLE
run migrations w/i messagingservice dev extension

### DIFF
--- a/dev/docker-compose.dev.messagingservice.yaml
+++ b/dev/docker-compose.dev.messagingservice.yaml
@@ -3,7 +3,7 @@
 version: "3.7"
 services:
   messagingservice:
-    command: sh -c "cd /opt/app && flask run --host 0.0.0.0 --port ${PORT:-8000}"
+    command: sh -c "cd /opt/app && flask upgrade && flask run --host 0.0.0.0 --port ${PORT:-8000}"
     environment:
       FLASK_ENV: development
     volumes:

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -276,6 +276,7 @@ services:
       - internal
     depends_on:
       - redis
+      - logs
 
   isaccml:
     image: ghcr.io/uwcirg/isacc-ml:${ISACCML_IMAGE_TAG:-main}


### PR DESCRIPTION
Add the automatic run of migrations to dev extension for messagingservice.

(critical when trying to debug migrations)